### PR TITLE
Handle multi-line error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   This allows the existing violations to be fixed once there is an auto-fix
   available.
 
+### Fixed
+
+- Multi-line error messages are now handled correctly.
+
 ## 0.1.0 -- 2023-10-10
 
 First release.

--- a/tests/silence_fixit_error_test.py
+++ b/tests/silence_fixit_error_test.py
@@ -17,7 +17,9 @@ isinstance(x, str) or isinstance(x, int)
     )
 
     assert violations == {
-        str(python_module): [Violation('CollapseIsinstanceChecks', 2)],
+        str(python_module): [
+            Violation(str(python_module), 'CollapseIsinstanceChecks', 2),
+        ],
     }
 
 

--- a/tests/silence_fixit_error_test.py
+++ b/tests/silence_fixit_error_test.py
@@ -1,8 +1,63 @@
 from __future__ import annotations
 
+import pytest
+
 from silence_fixit_error import _find_violations
+from silence_fixit_error import _parse_output_line
 from silence_fixit_error import main
 from silence_fixit_error import Violation
+
+
+@pytest.mark.parametrize(
+    'lines, expected_violations', (
+        pytest.param(
+            ['t.py@1:2 MyRuleName: the error message'],
+            [Violation('t.py', 'MyRuleName', 1)],
+            id='single-line',
+        ),
+        pytest.param(
+            [
+                't.py@1:2 MyRuleName: the error message',
+                'which continue over multiple lines',
+                'just like this one does.',
+            ],
+            [Violation('t.py', 'MyRuleName', 1), None, None],
+            id='multi-line',
+        ),
+        pytest.param(
+            [
+                't.py@1:2 MyRuleName: ',
+                'the error message on a new line',
+                'which continue over multiple lines',
+                'just like this one does.',
+            ],
+            [Violation('t.py', 'MyRuleName', 1), None, None, None],
+            id='multi-line-leading-ws',
+        ),
+        pytest.param(
+            [
+                't.py@1:2 MyRuleName: the error message',
+                'which continue over multiple lines',
+                'just like this one does.',
+                '',
+            ],
+            [Violation('t.py', 'MyRuleName', 1), None, None, None],
+            id='multi-line-trailing-ws',
+        ),
+        pytest.param(
+            ['t.py@1:2 MyRuleName: '],
+            [Violation('t.py', 'MyRuleName', 1)],
+            id='no-message',
+        ),
+    ),
+)
+def test_parse_output_line(lines, expected_violations):
+    violations = [
+        _parse_output_line(line)
+        for line in lines
+    ]
+
+    assert violations == expected_violations
 
 
 def test_find_violations(tmp_path, capsys):


### PR DESCRIPTION
Error messages can be arbitrary strings, so might include newline
characters. This means that parsing the fixit output line-wise will
cause us to encounter lines which are not error reports.